### PR TITLE
Make ceton plugin compatible with Windows.

### DIFF
--- a/ceton_conf.json
+++ b/ceton_conf.json
@@ -7,6 +7,12 @@
                     "valid_options": "list",
                     "description": "A Comma Seperated list of Ceton device IP addresses"
                 },
+          "pcie_ip":{
+                    "value": "none",
+                    "config_file": true,
+                    "config_web": true,
+                    "description": "IP assigned by the Ceton to the PCIe network interface"
+                },
 	  "device_tuners":{
                     "value": "4",
                     "config_file": true,

--- a/origin/__init__.py
+++ b/origin/__init__.py
@@ -42,7 +42,12 @@ class Plugin_OBJ():
                 self.tunerstatus[str(tuner_tmp_count)]['ceton_tuner'] = str(i)
 
                 if i == 0:
-                    hwtype = self.get_ceton_getvar( tuner_tmp_count, "HostConnection")
+                    while True:
+                        try:
+                            hwtype = self.get_ceton_getvar(tuner_tmp_count, "HostConnection")
+                            break
+                        except Exception as err:
+                            self.plugin_utils.logger.warning('%s, retrying.' % err)
                     self.plugin_utils.logger.info('Ceton hardware type: %s' % hwtype)
 
                 if 'pci' in hwtype and os.path.exists('/dev'): # won't work on windows


### PR DESCRIPTION
fHDHR does run on Windows (if Python and ffmpeg are properly installed and configured) but the ceton plugin requires some fixes:
- if pcie, detect if /dev does not exist and force UDP streaming
- set dest_ip to the IP assigned by the Ceton's DHCP server to the pcie network interface. Set pcie_ip in the config to this IP (default is 192.168.200.2)