### PR TITLE
Windows fixes

### DIFF
--- a/ceton_conf.json
+++ b/ceton_conf.json
@@ -1,14 +1,14 @@
 {
   "ceton":{
           "ceton_ip":{
-                    "value": "none",
+                    "value": "192.168.200.1",
                     "config_file": true,
                     "config_web": true,
                     "valid_options": "list",
                     "description": "A Comma Seperated list of Ceton device IP addresses"
                 },
           "pcie_ip":{
-                    "value": "none",
+                    "value": "192.168.200.2",
                     "config_file": true,
                     "config_web": true,
                     "description": "IP assigned by the Ceton to the PCIe network interface"
@@ -28,7 +28,7 @@
                     "description": "The total number of tuners for all Ceton devices"
                 },
           "stream_method":{
-                    "value": "ffmpeg",
+                    "value": "direct",
                     "config_file": true,
                     "config_web": true
                 },

--- a/ceton_conf.json
+++ b/ceton_conf.json
@@ -7,6 +7,12 @@
                     "valid_options": "list",
                     "description": "A Comma Seperated list of Ceton device IP addresses"
                 },
+          "pcie_ip":{
+                    "value": "none",
+                    "config_file": true,
+                    "config_web": true,
+                    "description": "IP assigned by the Ceton to the PCIe network interface"
+                },
 	  "device_tuners":{
                     "value": "4",
                     "config_file": true,

--- a/origin/__init__.py
+++ b/origin/__init__.py
@@ -42,7 +42,12 @@ class Plugin_OBJ():
                 self.tunerstatus[str(tuner_tmp_count)]['ceton_tuner'] = str(i)
 
                 if i == 0:
-                    hwtype = self.get_ceton_getvar( tuner_tmp_count, "HostConnection")
+                    while True:
+                        try:
+                            hwtype = self.get_ceton_getvar(tuner_tmp_count, "HostConnection")
+                            break
+                        except Exception as err:
+                            self.plugin_utils.logger.warning('%s, retrying.' % err)
                     self.plugin_utils.logger.info('Ceton hardware type: %s' % hwtype)
 
                 if 'pci' in hwtype and os.path.exists('/dev'): # won't work on windows

--- a/origin/__init__.py
+++ b/origin/__init__.py
@@ -52,12 +52,13 @@ class Plugin_OBJ():
                 else:
                     self.tunerstatus[str(tuner_tmp_count)]['ceton_pcie']  = False
                     self.tunerstatus[str(tuner_tmp_count)]['port']  = port + i
-                    self.tunerstatus[str(tuner_tmp_count)]['streamurl'] = "udp://127.0.0.1:%s" % (port + i)
                     # if we are using RTP on a pcie card, we need to stream to the ip it gives us
                     if 'pci' in hwtype:
-                        self.tunerstatus[str(tuner_tmp_count)]['dest_ip'] = self.pcie_ip
+                        dest_ip = self.pcie_ip
                     else:
-                        self.tunerstatus[str(tuner_tmp_count)]['dest_ip'] = self.plugin_utils.config.dict["fhdhr"]["address"]
+                        dest_ip = self.plugin_utils.config.dict["fhdhr"]["address"]
+                    self.tunerstatus[str(tuner_tmp_count)]['dest_ip'] = dest_ip
+                    self.tunerstatus[str(tuner_tmp_count)]['streamurl'] = "rtp://%s:%s" % (dest_ip, port + i)
 
                 self.startstop_ceton_tuner(tuner_tmp_count, 0)
                 tuner_tmp_count += 1


### PR DESCRIPTION
fHDHR does run on Windows but the Ceton plugin requires these fixes:

if PCIE, detect if /dev does not exist and force RTP streaming to the IP assigned by the ceton to its network interface. pcie_ip in config should be set to this IP. Direct RTP streaming (no ffmpeg) is possible as long as you are using a fixed version of fHDHR, see https://github.com/fHDHR/fHDHR/pull/341

A PCIE tuner will not respond immediately after boot or wake from sleep. If connect times out, retry until it succeeds. This reduces "tuner not found" or "unable to tune channel" errors in DVR apps.